### PR TITLE
Disable incomplete i18n for live site

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -56,7 +56,7 @@
                 <n-link class="n-link" to="/support">{{
                     $t('header.support')
                 }}</n-link>
-                <div class="desktop">
+                <!-- <div class="desktop">
                     <span :class="activeLang('zh')" @click="changeLang('zh')"
                         >中文</span
                     >
@@ -72,7 +72,7 @@
                     <div :class="activeLang('en')" @click="changeLang('en')">
                         EN
                     </div>
-                </div>
+                </div> -->
             </div>
         </div>
     </header>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -60,6 +60,11 @@ export default {
                     useCookie: true,
                     fallbackLocale: 'zh',
                 },
+                vueI18n: {
+                    // When no translation available,
+                    // fallback to zh-CN
+                    fallbackLocale: 'zh',
+                },
                 langDir: 'lang/',
                 locales: [
                     {
@@ -68,12 +73,12 @@ export default {
                         name: 'Chinese',
                         file: 'zh.js',
                     },
-                    {
-                        code: 'en',
-                        iso: 'en-US',
-                        name: 'English',
-                        file: 'en.js',
-                    },
+                    // {
+                    //     code: 'en',
+                    //     iso: 'en-US',
+                    //     name: 'English',
+                    //     file: 'en.js',
+                    // },
                 ],
                 strategy: 'no_prefix',
                 lazy: true,


### PR DESCRIPTION
Since the i18n translation hasn't been completed in the current build, disable the language switch function for now.